### PR TITLE
fix deprecated component

### DIFF
--- a/graphgym/loss.py
+++ b/graphgym/loss.py
@@ -13,8 +13,9 @@ def compute_loss(pred, true):
     :param true: label
     :return: loss, normalized prediction score
     '''
-    bce_loss = nn.BCEWithLogitsLoss(size_average=cfg.model.size_average)
-    mse_loss = nn.MSELoss(size_average=cfg.model.size_average)
+    r = 'mean' if cfg.model.size_average else 'sum'
+    bce_loss = nn.BCEWithLogitsLoss(reduction=r)
+    mse_loss = nn.MSELoss(reduction=r)
 
     # default manipulation for pred and true
     # can be skipped if special loss computation is needed


### PR DESCRIPTION
The original code leads to an UserWarning by PyTorch:
`... /ml/lib/python3.7/site-packages/torch/nn/_reduction.py:44: UserWarning: size_average and reduce args will be deprecated, please use reduction='mean' instead.`
since the `size_average` and  `reduce` kwargs are deprecated and replaced by `reduction` kwarg. See `https://pytorch.org/docs/stable/generated/torch.nn.BCEWithLogitsLoss.html?highlight=bcewithlogitsloss#torch.nn.BCEWithLogitsLoss`.