### PR TITLE
enabled fixed order split

### DIFF
--- a/graphgym/config.py
+++ b/graphgym/config.py
@@ -92,6 +92,9 @@ def set_cfg(cfg):
     # Split ratio of dataset. Len=2: Train, Val. Len=3: Train, Val, Test
     cfg.dataset.split = [0.8, 0.1, 0.1]
 
+    # Whether to shuffle the graphs for splitting
+    cfg.dataset.shuffle_split = True
+
     # Whether to use an encoder for the node features
     cfg.dataset.node_encoder = False
 

--- a/graphgym/loader.py
+++ b/graphgym/loader.py
@@ -86,7 +86,7 @@ def load_nx(name, dataset_dir):
         with open('{}/{}.pkl'.format(dataset_dir, name), 'rb') as file:
             graphs = pickle.load(file)
     except:
-        graphs = nx.read_gpickle('{}.gpickle'.format(dataset_dir, name))
+        graphs = nx.read_gpickle('{}/{}.gpickle'.format(dataset_dir, name))
         if not isinstance(graphs, list):
             graphs = [graphs]
     return graphs
@@ -226,7 +226,8 @@ def create_dataset():
     else:
         datasets = dataset.split(
             transductive=cfg.dataset.transductive,
-            split_ratio=cfg.dataset.split)
+            split_ratio=cfg.dataset.split,
+            shuffle=cfg.dataset.shuffle_split)
     # We only change the training negative sampling ratio
     for i in range(1, len(datasets)):
         dataset.edge_negative_sampling_ratio = 1


### PR DESCRIPTION
In some settings, e.g., extrapolation on graph theory algorithms, the last n% elements in the list of graphs have a larger graph scale, and we intend to use the last n% elements as test set. Thus, we should not shuffle the list of graphs during splitting.