### PR TITLE
enabled specifying metric aggregator

### DIFF
--- a/graphgym/config.py
+++ b/graphgym/config.py
@@ -59,6 +59,9 @@ def set_cfg(cfg):
     # The metric for selecting the best epoch for each run
     cfg.metric_best = 'auto'
 
+    # argmax or argmin in aggregating results
+    cfg.metric_agg = 'argmax'
+
     # If visualize embedding.
     cfg.view_emb = False
 

--- a/graphgym/utils/agg_runs.py
+++ b/graphgym/utils/agg_runs.py
@@ -84,7 +84,7 @@ def agg_runs(dir, metric_best='auto'):
                 else:
                     metric = metric_best
                 performance_np = np.array([stats[metric] for stats in stats_list])
-                best_epoch = stats_list[performance_np.argmax()]['epoch']
+                best_epoch = stats_list[eval("performance_np.{}()".format(cfg.metric_agg))]['epoch']
                 print(best_epoch)
 
             for split in os.listdir(dir_seed):
@@ -189,7 +189,7 @@ def agg_batch(dir, metric_best='auto'):
                     else:
                         metric = metric_best
                     performance_np = np.array([stats[metric] for stats in dict_stats])
-                    dict_stats = dict_stats[performance_np.argmax()]
+                    dict_stats = dict_stats[eval("performance_np.{}()".format(cfg.metric_agg))]
                     rm_keys(dict_stats, ['lr', 'lr_std', 'eta', 'eta_std','params_std'])
                     results[split].append({**dict_name, **dict_stats})
     dir_out = os.path.join(dir, 'agg')


### PR DESCRIPTION
Different from metrics, e.g., AUC and Accuracy, that we prefer the epoch where we achieve the largest metric, we prefer the smallest one when we consider metrics, e.g., "MSE" and "MAE".