### PR TITLE
Enhance GeneralConvLayer

### DIFF
--- a/graphgym/config.py
+++ b/graphgym/config.py
@@ -344,6 +344,9 @@ def set_cfg(cfg):
     # e.g., when cfg.gnn.layer_type = 'generalconv'
     cfg.gnn.agg = 'add'
 
+    # Message passing flow: source_to_target or target_to_source
+    cfg.gnn.flow = 'source_to_target'
+
     # Normalize adj
     cfg.gnn.normalize_adj = False
 

--- a/graphgym/contrib/layer/generalconv.py
+++ b/graphgym/contrib/layer/generalconv.py
@@ -66,7 +66,7 @@ class GeneralConvLayer(MessagePassing):
                 deg = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
             deg_inv_sqrt = deg.pow(-1.0)
             deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
-            norm = deg_inv_sqrt * edge_weight
+            norm = (deg_inv_sqrt[row] if cfg.gnn.flow == 'source_to_target' else deg_inv_sqrt[col]) * edge_weight
 
         return edge_index, norm
 

--- a/graphgym/contrib/layer/generalconv.py
+++ b/graphgym/contrib/layer/generalconv.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from torch.nn import Parameter
 from torch_scatter import scatter_add
 from torch_geometric.nn.conv import MessagePassing
-from torch_geometric.utils import add_remaining_self_loops
+from torch_geometric.utils import add_remaining_self_loops, is_undirected
 
 from torch_geometric.nn.inits import glorot, zeros
 from graphgym.config import cfg
@@ -15,7 +15,7 @@ class GeneralConvLayer(MessagePassing):
 
     def __init__(self, in_channels, out_channels, improved=False, cached=False,
                  bias=True, **kwargs):
-        super(GeneralConvLayer, self).__init__(aggr=cfg.gnn.agg, **kwargs)
+        super(GeneralConvLayer, self).__init__(aggr=cfg.gnn.agg, flow=cfg.gnn.flow, **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -54,11 +54,21 @@ class GeneralConvLayer(MessagePassing):
             edge_index, edge_weight, fill_value, num_nodes)
 
         row, col = edge_index
-        deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
-        deg_inv_sqrt = deg.pow(-0.5)
-        deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
+        if is_undirected(edge_index, num_nodes=num_nodes):
+            deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+            deg_inv_sqrt = deg.pow(-0.5)
+            deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
+            norm = deg_inv_sqrt[row] * edge_weight * deg_inv_sqrt[col]
+        else:
+            if cfg.gnn.flow == 'source_to_target':
+                deg = scatter_add(edge_weight, row, dim=0, dim_size=num_nodes)
+            else:
+                deg = scatter_add(edge_weight, col, dim=0, dim_size=num_nodes)
+            deg_inv_sqrt = deg.pow(-1.0)
+            deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
+            norm = deg_inv_sqrt * edge_weight
 
-        return edge_index, deg_inv_sqrt[row] * edge_weight * deg_inv_sqrt[col]
+        return edge_index, norm
 
     def forward(self, x, edge_index, edge_weight=None, edge_feature=None):
         """"""
@@ -81,6 +91,10 @@ class GeneralConvLayer(MessagePassing):
                                              edge_weight, self.improved,
                                              x.dtype)
             else:
+                if cfg.gnn.self_msg == 'none':
+                    # add self-loop to ensure the final output has considered h_{v}^{l-1}
+                    edge_index, edge_weight = add_remaining_self_loops(
+                        edge_index, edge_weight, 2 if self.improved else 1, x.size(self.node_dim))
                 norm = edge_weight
             self.cached_result = edge_index, norm
 
@@ -120,7 +134,7 @@ class GeneralEdgeConvLayer(MessagePassing):
 
     def __init__(self, in_channels, out_channels, improved=False, cached=False,
                  bias=True, **kwargs):
-        super(GeneralEdgeConvLayer, self).__init__(aggr=cfg.gnn.agg, **kwargs)
+        super(GeneralEdgeConvLayer, self).__init__(aggr=cfg.gnn.agg, flow=cfg.gnn.flow, **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels


### PR DESCRIPTION
1. added `gnn.flow` argument to enable message passing in either direction for directed graphs.
2. thus, also enabled `GeneralConvLayer` to normalize the adjacency matrix of directed graphs according to [the discussion](https://github.com/tkipf/gcn/issues/91)
3. When there is no self message and adj has not been normalized, that is, `gnn.self_msg=="none" and `gnn.normalize_adj==False`, no self loop would be added. Thus, in the  current implementation, the message passing procedure ignored the node's embedding at previous layer, i.e., $$h_{v}^{(l-1)}$$, which is inconsistent with the convention.


I tested this pr:

```python
cfg.gnn.normalize_adj = True#False
cfg.gnn.self_msg = 'none'
cfg.gnn.agg = 'add'
cfg.gnn.flow = "target_to_source"
conv = GeneralConvLayer(1, 1, bias=False)
conv.weight.data = torch.ones((1, 1))
x = torch.Tensor([[1], [2], [3], [4], [5]]).to(torch.float32)
edge_index = torch.Tensor([[0, 1, 2, 2], [2, 2, 0, 4]]).to(torch.int64)
#edge_index = to_undirected(edge_index, x.size(0))
out = conv(x, edge_index)
print(out)
```

the output matches what we expected:
```shell
tensor([[1.5000],
        [3.0000],
        [4.0000],
        [4.0000],
        [2.5000]], grad_fn=<ScatterAddBackward>)
```

if we changed to `cfg.gnn.flow="source_to_target"` as usual, it results in:
```shell
tensor([[1.5000],
        [1.0000],
        [2.5000],
        [4.0000],
        [6.0000]], grad_fn=<ScatterAddBackward>)
```
which is also what we expected.

