### PR TITLE
use float instead of int for fill_value

### DIFF
--- a/graphgym/contrib/layer/attconv.py
+++ b/graphgym/contrib/layer/attconv.py
@@ -54,7 +54,7 @@ class GeneralAddAttConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -157,7 +157,7 @@ class GeneralMulAttConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -303,7 +303,7 @@ class GeneralEdgeAttConvv1Layer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -442,7 +442,7 @@ class GeneralEdgeAttConvv2Layer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 

--- a/graphgym/contrib/layer/generalconv.py
+++ b/graphgym/contrib/layer/generalconv.py
@@ -49,7 +49,7 @@ class GeneralConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -157,7 +157,7 @@ class GeneralEdgeConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 

--- a/graphgym/contrib/layer/generalconv_ogb.py
+++ b/graphgym/contrib/layer/generalconv_ogb.py
@@ -73,7 +73,7 @@ class GeneralOGBConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 

--- a/graphgym/contrib/layer/generalconv_v2.py
+++ b/graphgym/contrib/layer/generalconv_v2.py
@@ -49,7 +49,7 @@ class GeneralConvLayerV2(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -171,7 +171,7 @@ class GeneralEdgeConvLayerV2(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 

--- a/graphgym/contrib/layer/idconv.py
+++ b/graphgym/contrib/layer/idconv.py
@@ -48,7 +48,7 @@ class GeneralIDConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 
@@ -136,7 +136,7 @@ class GCNIDConvLayer(MessagePassing):
             edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                      device=edge_index.device)
 
-        fill_value = 1 if not improved else 2
+        fill_value = 1.0 if not improved else 2.0
         edge_index, edge_weight = add_remaining_self_loops(
             edge_index, edge_weight, fill_value, num_nodes)
 

--- a/graphgym/contrib/transform/identity.py
+++ b/graphgym/contrib/transform/identity.py
@@ -10,7 +10,7 @@ def norm(edge_index, num_nodes, edge_weight=None, improved=False,
         edge_weight = torch.ones((edge_index.size(1),), dtype=dtype,
                                  device=edge_index.device)
 
-    fill_value = 1 if not improved else 2
+    fill_value = 1.0 if not improved else 2.0
     edge_index, edge_weight = add_remaining_self_loops(
         edge_index, edge_weight, fill_value, num_nodes)
 


### PR DESCRIPTION
In torch-geometry version 2.0.2, which is the version automatically installed with pip 21.1.3, `add_remaining_self_loops` accepts `fill_value` as one of float, tensor or str.
Although in latest torch-geometric package, int value is accepted and treated the same way as float, it could be more robust to set fill_value as float.