### PR TITLE
Fix for custom configs not resolving correctly

### DIFF
--- a/graphgym/config.py
+++ b/graphgym/config.py
@@ -575,9 +575,6 @@ def set_run_dir(out_dir):
         makedirs_rm_exist(cfg.run_dir)
 
 
-set_cfg(cfg)
-
-
 def from_config(func):
     if inspect.isclass(func):
         params = list(inspect.signature(func.__init__).parameters.values())[1:]
@@ -603,3 +600,16 @@ def from_config(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+
+# 1. set default cfg values first, some modules in contrib might rely on this
+set_cfg(cfg) 
+
+# 2. load the graph contrib tree to register custom configs
+import graph.contrib.config
+
+# 3. re-register custom configs into cfg
+for func in register.config_dict.values():
+    func(cfg)
+


### PR DESCRIPTION
Creating custom configs in `graphgym/contrib` does not currently work correctly as far as I can tell. 

Trying to specify `example_arg` or `example_group` -- arguments from the example contrib config -- yields an error as the config does not have those keys resolved yet, so cfg merge method refuses to merge unrecognized keys.

```
Traceback (most recent call last):
  File "/home/rdyro/Desktop/GraphGym/run/main.py", line 23, in <module>
    load_cfg(cfg, args)
  File "/home/rdyro/.pyenv/versions/devel/lib/python3.9/site-packages/graphgym/config.py", line 517, in load_cfg
    cfg.merge_from_file(args.cfg_file)
  File "/home/rdyro/.pyenv/versions/devel/lib/python3.9/site-packages/yacs/config.py", line 213, in merge_from_file
    self.merge_from_other_cfg(cfg)
  File "/home/rdyro/.pyenv/versions/devel/lib/python3.9/site-packages/yacs/config.py", line 217, in merge_from_other_cfg
    _merge_a_into_b(cfg_other, self, self, [])
  File "/home/rdyro/.pyenv/versions/devel/lib/python3.9/site-packages/yacs/config.py", line 491, in _merge_a_into_b
    raise KeyError("Non-existent config key: {}".format(full_key))
KeyError: 'Non-existent config key: example_arg'
```

The issue seems to have to do these line within the `set_cfg` function
```python
for func in register.config_dict.values():
    func(cfg)
```
which operate over an empty dictionary, because `graphgym.contrib` has not yet been imported at that stage. However, importing `graphgym.contrib` directly in the config file leads to another set of errors as a couple of examples in `graphgym.contrib` rely on `cfg` having been initialized to the default structure.

The fix appears to require:
1. setting the cfg tree to a default structure with `set_cfg(cfg)`
2. importing the gaphgym.contrib tree
3. rerunning the following lines in the global file definition to now properly register custom config fields
```
for func in register.config_dict.values():
    func(cfg)
```